### PR TITLE
Enhance Security: Enforce HTTPS & HSTS

### DIFF
--- a/lib/templates/ingress.yml
+++ b/lib/templates/ingress.yml
@@ -34,6 +34,10 @@ metadata:
     <% end %>
     
     <% if ingress.ingress_class.to_s == 'nginx' %>
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/hsts: "true"
+    nginx.ingress.kubernetes.io/hsts-max-age: "31536000"
+    nginx.ingress.kubernetes.io/hsts-include-subdomains: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: <%= ingress.max_body_size || '50m' %>
     <% end %>
 


### PR DESCRIPTION
## What does this PR do?

- Ensures all traffic is securely redirected to HTTPS.
- Instructs browsers to cache secure connection settings, reducing downgrade attacks.
- Applies security across all subdomains.